### PR TITLE
Fix module loading for browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,5 @@
 <body><div id="wrap"><canvas id="game" width="640" height="480"></canvas><div id="log">
 <div><span class="tag">Hint</span> このテンプレートは <b>XML→JS</b> の移植用です。assets/data に Map*.xml / RPG_RT.xml を置けば読み込みできます。</div>
 <hr/><pre id="console"></pre></div></div>
-<script src="./js/config.js"></script>
-<script src="./js/dataLoader.js"></script>
-<script src="./js/map.js"></script>
-<script src="./js/player.js"></script>
-<script src="./js/eventEngine.js"></script>
-<script src="./js/main.js"></script>
+<script type="module" src="./js/main.js"></script>
 </body></html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
-import{CONFIG}from"./config.js";import{TileMap}from"./map.js";import{Player}from"./player.js";import{fallbackMap16x16,fetchXML,parseLowerLayer}from"./dataLoader.js";
+import{CONFIG}from"./config.js";import{TileMap}from"./map.js";import{Player}from"./player.js";import{fallbackMap16x16,fetchXML,parseLowerLayer}from"./dataLoader.js";import{EventInterpreter,Maniacs,executeEventCommand,parseParameters,parseEventCommands}from"./eventEngine.js";
 function log(...a){const e=document.getElementById("console");if(e){e.textContent+=a.join(" ")+"\n";e.scrollTop=e.scrollHeight;}console.log(...a);}
-const canvas=document.getElementById("game"),ctx=canvas.getContext("2d"),keys={};window.addEventListener("keydown",e=>keys[e.key]=true);window.addEventListener("keyup",e=>keys[e.key]=false);
+const canvas=document.getElementById("game"),ctx=canvas.getContext("2d"),keys={};window.addEventListener("keydown",e=>keys[e.key]=true);window.addEventListener("keyup",e=>keys[e.key]=false);window.EventEngine={EventInterpreter,Maniacs,executeEventCommand,parseParameters,parseEventCommands};
 let map=new TileMap(fallbackMap16x16()),player=new Player(32,200),camX=0;(async()=>{try{const p=Object.values(CONFIG.dataPaths);if(p.length){const f=p[0];log("[Load]",f);const d=await fetchXML(f);const data=parseLowerLayer(d);
 map=new TileMap(data);log("[OK]",f,"("+data.width+"x"+data.height+")");}else log("[Info]XMLをassets/dataに置いてconfig.jsを設定してください。");}catch(e){log("[Warn]",e.message);}})();
 function upd(){player.update(keys,map);camX=Math.max(0,Math.floor(player.x-canvas.width/2));camX=Math.min(camX,map.width*CONFIG.tileSize-canvas.width);}


### PR DESCRIPTION
## Summary
- load the application entry point as an ES module so the browser accepts exported code
- expose the event engine helpers on `window` for access when running in the browser console

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3ecb4e138832ba31620d2ee3476d0